### PR TITLE
feat: add -show-functions for Source folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# SPM lcov action
+# Fork
 
-Swift Package Manager Code Coverage Report.
+# SPM lcov action functions
+
+Swift Package Manager Code Coverage Report /w Detailed Functions
+
+This is a fork of Maxime Epain's spm-lcov-action Github Action. Unlike his, this one passes in the -show-functions command, hardcoded to the Sources directory (standard for Swift Package Manager-templated Swift project), giving more detailed information on which functions are not fully covered or covered at all.
 
 ## Summary Report
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Swift Coverage Report'
-description: 'Report SPM test coverage summary and lcov file'
-author: 'Maxime Epain'
+name: 'Swift Coverage Report w/ Detailed Functions'
+description: 'Report SPM test coverage per function and lcov file'
+author: 'Algorand Foundation'
 branding:
     icon: 'check-circle'  
     color: 'orange'

--- a/cov.sh
+++ b/cov.sh
@@ -36,7 +36,8 @@ llvm-cov report \
     "${COV_BIN}" \
     -instr-profile=$INSTR_PROFILE \
     -ignore-filename-regex=$IGNORE_FILENAME_REGEX \
-    -use-color
+    -use-color \
+    -show-functions Sources
 
 llvm-cov export \
     "${COV_BIN}" \


### PR DESCRIPTION
Tried it out with my personal fork and the bip32-ed25519-swift library. Hard coded to Sources folder.